### PR TITLE
Temporarily step ruby version back for RP.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.3.0'
 
 gem 'mocha'
 gem 'rack-test'


### PR DESCRIPTION
Step Ruby version back to 2.3.0 since cloud.gov doesn't support 2.3.1 yet.