### PR TITLE
add uscis specific success page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@ class RelyingParty < Sinatra::Base
     whitelist = ['uscis']
 
     if whitelist.include?(agency)
-      erb :"agency/#{agency}", :layout => false
+      erb :"agency/#{agency}/index", :layout => false
     else
       erb :index
     end
@@ -36,7 +36,8 @@ class RelyingParty < Sinatra::Base
   end
 
   get '/success/?' do
-    erb :success
+    # default to uscis success page for now
+    erb :"agency/uscis/success", :layout => false
   end
 
   post '/consume/?' do

--- a/views/agency/uscis/index.erb
+++ b/views/agency/uscis/index.erb
@@ -13,14 +13,14 @@
   </style>
 </head>
 <body>
-  <div class="center absolute top-0 left-0 right-0">
-    <img src="/img/uscis/logo.png">
-  </div>
-  <div class="bg-navy white px2 py1 clearfix">
+  <div class="relative bg-navy white px2 py1 clearfix">
     <div class="container sm-show">
       <div class="sm-col-right">
         <div class="h6">Español | Blog | About USCIS | Contact Us</div>
       </div>
+    </div>
+    <div class="absolute top-0 left-0 right-0 center">
+      <img src="/img/uscis/logo.png">
     </div>
   </div>
   <div class="relative border-bottom p2 clearfix">

--- a/views/agency/uscis/success.erb
+++ b/views/agency/uscis/success.erb
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Identity</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link href="/css/lib/basscss.min.css" rel="stylesheet">
+  <style>
+  .bg-navy { background-color: #003366; }
+  .bg-cover   { background-size: cover; }
+  .bg-hero { background-image: url(/img/uscis/hero.jpg); }
+  .hero-inner { height: 250px; }
+  </style>
+</head>
+<body>
+  <div class="h5 p2 bg-green white center">
+    <span class="bold caps">Success!</span>
+    <% if session[:email] %>
+    <span>Your email is <strong><%= session[:email] %></strong></span>
+    <% end %>
+  </div>
+  <div class="relative bg-navy white px2 py1 clearfix">
+    <div class="container sm-show">
+      <div class="sm-col-right">
+        <div class="h6">Español | Blog | About USCIS | Contact Us</div>
+      </div>
+    </div>
+    <div class="absolute top-0 left-0 right-0 center">
+      <img src="/img/uscis/logo.png">
+    </div>
+  </div>
+  <div class="relative border-bottom p2 clearfix">
+    <div class="container sm-show">
+      <div class="sm-col">
+        <a href="#!" class="h5 btn p0 py1">A-Z Index</a> |
+        <a href="#!" class="h5 btn p0 py1">Get Email Updates</a>
+      </div>
+      <div class="sm-col-right">
+        <a href="#!" class="h5 btn p0 py1">Search our Site</a> |
+        <a href="#!" class="h5 btn p0 py1">Ask a Question</a>
+      </div>
+    </div>
+  </div>
+  <div class="bg-darken-1 py1 sm-show">
+    <div class="container">
+      <div class="sm-flex center nowrap caps">
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">Forms</a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">News</a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">Citizenship</a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block"><%= '&nbsp;' * 10 %></a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">Green Card</a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">Tools</a>
+        </div>
+        <div class="flex-auto">
+          <a href="#!" class="h5 btn block">Laws</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="container">
+    <div class="bg-silver py4 bg-cover bg-hero">
+      <div class="sm-show hero-inner"></div>
+    </div>
+    <div class="clearfix p2 mxn2 center">
+      <div class="sm-col sm-col-4 px2">
+        <img src="/img/uscis/ico-1.png">
+        <h2 class="h3 mt0 mb1">Check your Case Status</h2>
+        <p>Track your application or petition as it moves through the immigration process</p>
+      </div>
+      <div class="sm-col sm-col-4 px2">
+        <img src="/img/uscis/ico-2.png">
+        <h2 class="h3 mt0 mb1">Find a USCIS Office</h2>
+        <p>Locate your nearest&nbsp;field or international USCIS office</p>
+      </div>
+      <div class="sm-col sm-col-4 px2">
+        <img src="/img/uscis/ico-3.png">
+        <h2 class="h3 mt0 mb1">Make an Appointment</h2>
+        <p>Schedule a free appointment to visit a local USCIS office and get answers on your case</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/views/success.erb
+++ b/views/success.erb
@@ -1,10 +1,26 @@
 <div class="clearfix">
   <div class="col-12 sm-col-6 mx-auto">
-    <div class="p2 bg-green white center">
-      <div class="h2 bold">Success!</div>
+    <div class="h5 p2 bg-green white center">
+      <span class="bold caps">Success!</span>
       <% if session[:email] %>
-      <div>Your email is <strong><%= session[:email] %></strong></div>
+      <span>Your email is <strong><%= session[:email] %></strong>.</span>
       <% end %>
     </div>
   </div>
+</div>
+
+<div class="clearfix py3 mxn1">
+  <% (0..7).each do |i| %>
+    <div class="sm-col sm-col-6 px1">
+      <div class="p2 mb2 bg-white rounded">
+        <div class="p1 mb1 bg-darken-1 col-7"></div>
+        <div class="p1 mb1 bg-darken-1 col-10"></div>
+        <div class="p1 mb1 bg-darken-1 col-5"></div>
+        <div class="p1 mb1 bg-darken-1 col-8"></div>
+        <div class="p1 mb1 bg-darken-1 col-6"></div>
+        <div class="p1 mb1 bg-darken-1 col-11"></div>
+        <div class="p1 mb1 bg-darken-1 col-8"></div>
+      </div>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Add USCIS specific success page and default to that (for now). Before, we add a mismatch -- you started at the USCIS mock homepage and then went to a generic agency success page upon log in.

![image](https://cloud.githubusercontent.com/assets/1060893/15294742/75d9505c-1b5b-11e6-9d6b-52c530b6a533.png)

Note: The USCIS index and success pages could be more DRY (lots of shared content, but I figured that's okay for now since we're (likely?) migrating this to a Rails app soon.