### PR TITLE
Add Basic HTTP Auth to identity-rp.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,10 @@ require 'yaml'
 class RelyingParty < Sinatra::Base
   enable :sessions
 
+  use Rack::Auth::Basic, "Restricted" do |username, password|
+    username == '18f' and password == 'Trust But Verify'
+  end
+
   def init(uri)
     @auth_server_uri = uri
   end

--- a/config/saml_settings.yml
+++ b/config/saml_settings.yml
@@ -1,8 +1,9 @@
 ---
-assertion_consumer_service_url: http://localhost:4567/consume
+assertion_consumer_service_url: https://identity-rp-dev.apps.cloud.gov/consume
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-issuer: USA-RUBY-SP
-idp_sso_target_url: https://upaya-idp-dev.18f.gov/api/saml/auth
+issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev
+idp_sso_target_url: https://upaya-idp-demo.18f.gov/api/saml/auth
+idp_slo_target_url: https://upaya-idp-demo.18f.gov/api/saml/logout
 idp_cert_fingerprint: 95c879e4a3402be6e3497d3038cfe98336833565
 name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 authn_context: http://idmanagement.gov/ns/assurance/loa/1


### PR DESCRIPTION
Why:
 - Apps need to be HTTP Auth protected.

How:
 - Add Sinatra's HTTP Auth.

Fix issue 313